### PR TITLE
Send word to all players

### DIFF
--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -87,11 +87,7 @@ class ConnectionManager:
                 if tries_per_player:
                     tries_left = max(tries_per_player - attempts, 0)
 
-                word_for_player = (
-                    state.get("current_word")
-                    if state.get("current_master") == name
-                    else None
-                )
+                word_for_player = state.get("current_word")
 
                 pg_state = PlayerGameState(
                     expires_at=state["expires_at"],

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -162,6 +162,7 @@ function createPlayerSection(defaultName = '', defaultId = '', autoJoin = false)
             const isMaster = data.current_master === name;
             masterArea.style.display = isMaster ? 'block' : 'none';
             masterWordEl.textContent = isMaster ? (data.current_word || '') : '';
+            container.dataset.currentWord = data.current_word || '';
             masterSkip.style.display = isMaster ? 'inline' : 'none';
             if (isMaster) {
                 disabled = true;
@@ -191,6 +192,10 @@ function createPlayerSection(defaultName = '', defaultId = '', autoJoin = false)
     sendGuess.onclick = () => {
         const guess = guessInput.value.trim();
         if (socket && guess) {
+            const currentWord = (container.dataset.currentWord || '').toLowerCase();
+            if (currentWord && guess.toLowerCase() === currentWord) {
+                logMessage('Player ' + name + ' local check: guess matches');
+            }
             socket.send(JSON.stringify({ action: 'guess', guess }));
             guessInput.value = '';
         }


### PR DESCRIPTION
## Summary
- always include current word when sending game state to players
- store the current word in player sections and locally verify guesses

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855be47c05c8329b05f9571c98fa0a8