### PR TITLE
Add backend tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,56 @@
+import os
+import types
+import sys
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from fastapi.testclient import TestClient
+import mongomock_motor
+
+# Provide a fake motor module before importing the app's db module to avoid
+# importing the real Motor client (which requires pymongo features not
+# installed).
+motor_mock = types.ModuleType("motor")
+motor_asyncio = types.ModuleType("motor.motor_asyncio")
+motor_asyncio.AsyncIOMotorClient = mongomock_motor.AsyncMongoMockClient
+motor_mock.motor_asyncio = motor_asyncio
+sys.modules.setdefault("motor", motor_mock)
+sys.modules.setdefault("motor.motor_asyncio", motor_asyncio)
+
+os.environ.setdefault("SECRET_KEY", "test_secret")
+os.environ.setdefault("ALGORITHM", "HS256")
+os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+
+import backend.app.db as db_module
+import backend.app.services.auth_service as auth_service
+import backend.app.services.game_service as game_service
+import backend.app.routers.profile as profile_router
+import backend.app.routers.game as game_router
+import backend.app.code_gen as code_gen
+from backend.app.main import app as fastapi_app
+
+@pytest_asyncio.fixture
+async def test_db(monkeypatch):
+    client = mongomock_motor.AsyncMongoMockClient()
+    test_db = client.db
+    monkeypatch.setattr(db_module, "db", test_db)
+    monkeypatch.setattr(auth_service, "users", test_db.users)
+    monkeypatch.setattr(game_service, "games", test_db.games)
+    monkeypatch.setattr(game_service, "decks", test_db.decks)
+    monkeypatch.setattr(game_router, "games", test_db.games)
+    monkeypatch.setattr(game_router, "db", test_db)
+    monkeypatch.setattr(profile_router, "db", test_db)
+    monkeypatch.setattr(code_gen, "games", test_db.games)
+    monkeypatch.setattr(code_gen, "decks", test_db.decks)
+    monkeypatch.setattr(code_gen, "users", test_db.users)
+    yield test_db
+
+@pytest_asyncio.fixture
+async def client(test_db):
+    async with AsyncClient(app=fastapi_app, base_url="http://test") as c:
+        yield c
+
+@pytest.fixture
+def sync_client(test_db):
+    with TestClient(fastapi_app) as c:
+        yield c

--- a/backend/tests/test_auth_unit.py
+++ b/backend/tests/test_auth_unit.py
@@ -1,0 +1,83 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from backend.app.models import UserInDB
+
+# 1 Register new user succeeds
+def test_register_new_user_succeeds(sync_client, monkeypatch):
+    mock_get_user = AsyncMock(return_value=None)
+    mock_create_user = AsyncMock()
+    mock_create_access_token = MagicMock(return_value="tok")
+    monkeypatch.setattr("backend.app.routers.auth.get_user", mock_get_user)
+    monkeypatch.setattr("backend.app.routers.auth.create_user", mock_create_user)
+    monkeypatch.setattr("backend.app.routers.auth.create_access_token", mock_create_access_token)
+
+    payload = {"name": "John", "surname": "Doe", "email": "john@example.com", "password": "pw"}
+    response = sync_client.post("/api/auth/register", json=payload)
+
+    assert response.status_code == 200
+    mock_create_user.assert_called_once()
+    assert mock_create_user.call_args.args[0].email == payload["email"]
+    mock_create_access_token.assert_called_once()
+    assert mock_create_access_token.call_args.kwargs["data"] == {"sub": payload["email"]}
+    data = response.json()
+    assert data["token_type"] == "bearer" and data["access_token"]
+
+
+# 2 Register existing email fails
+def test_register_existing_email_fails(sync_client, monkeypatch):
+    mock_get_user = AsyncMock(return_value={"_id": "1"})
+    monkeypatch.setattr("backend.app.routers.auth.get_user", mock_get_user)
+
+    payload = {"name": "John", "surname": "Doe", "email": "john@example.com", "password": "pw"}
+    response = sync_client.post("/api/auth/register", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Email already registered"
+
+
+# 3 Login with correct credentials returns token
+def test_login_correct_credentials(sync_client, monkeypatch):
+    user = UserInDB(id="u1", name="A", surname="B", email="a@b.c", hashed_password="h")
+    mock_auth = AsyncMock(return_value=user)
+    mock_create_access_token = MagicMock(return_value="tok")
+    monkeypatch.setattr("backend.app.routers.auth.authenticate_user", mock_auth)
+    monkeypatch.setattr("backend.app.routers.auth.create_access_token", mock_create_access_token)
+
+    response = sync_client.post("/api/auth/login", data={"username": user.email, "password": "pw"})
+
+    assert response.status_code == 200
+    mock_create_access_token.assert_called_once()
+    assert mock_create_access_token.call_args.kwargs["data"] == {"sub": user.email}
+    body = response.json()
+    assert body["token_type"] == "bearer" and body["access_token"]
+
+
+# 4 Login with bad credentials fails
+def test_login_bad_credentials(sync_client, monkeypatch):
+    monkeypatch.setattr("backend.app.routers.auth.authenticate_user", AsyncMock(return_value=None))
+
+    response = sync_client.post("/api/auth/login", data={"username": "x", "password": "y"})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Incorrect email or password"
+
+
+# 5 Export deck as TXT returns correct file
+def test_export_deck_txt(sync_client, test_db, monkeypatch):
+    asyncio.get_event_loop().run_until_complete(
+        test_db.games.insert_one({"_id": "g1", "deck": ["a", "b", "c"]})
+    )
+    response = sync_client.get("/api/game/leaderboard/g1/export")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert "exported_deck_" in response.headers.get("content-disposition", "")
+    assert response.text == "a\nb\nc"
+
+
+# additional unit test for required_to_advance
+from backend.app.services.game_service import required_to_advance
+
+def test_required_to_advance_logic():
+    state = {"scores": {"alice": 1, "bob": 2, "carol": 3}, "current_master": "alice", "right_answers_to_advance": 3}
+    assert required_to_advance(state) == 2

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,0 +1,78 @@
+import pytest
+import pytest_asyncio
+
+# helper fixture to create a game and return id and words
+@pytest_asyncio.fixture
+async def created_game(client, monkeypatch):
+    monkeypatch.setattr("backend.app.routers.game.shuffle", lambda x: None)
+    words = ["a", "b", "c"]
+    resp = await client.post("/api/game/create", json={"remaining_words": words, "words_amount": 3})
+    game_id = resp.json()["id"]
+    return game_id, words
+
+# 1 End-to-end user flow
+@pytest.mark.asyncio
+async def test_end_to_end_flow(client):
+    user = {"name": "Ann", "surname": "Doe", "email": "ann@example.com", "password": "pw"}
+    r1 = await client.post("/api/auth/register", json=user)
+    assert r1.status_code == 200
+    r2 = await client.post("/api/auth/login", data={"username": user["email"], "password": user["password"]})
+    token = r2.json()["access_token"]
+    r3 = await client.get("/api/profile/me", headers={"Authorization": f"Bearer {token}"})
+    assert r3.status_code == 200
+    data = r3.json()
+    assert data["email"] == user["email"]
+
+# 2 Deck save & profile listing
+@pytest.mark.asyncio
+async def test_deck_save_and_profile_listing(client, test_db):
+    user = {"name": "Bob", "surname": "Smith", "email": "bob@example.com", "password": "pw"}
+    await client.post("/api/auth/register", json=user)
+    login = await client.post("/api/auth/login", data={"username": user["email"], "password": user["password"]})
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    words = {"w1": "one", "w2": "two"}
+    res = await client.post(
+        "/api/game/g1/deck/save?deck_name=Test&tags=foo,bar",
+        json={"words": words},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    user_doc = await test_db.users.find_one({"email": user["email"]})
+    deck_doc = await test_db.decks.find_one({"_id": res.json()["inserted_id"]})
+    assert deck_doc and deck_doc["name"] == "Test"
+    assert deck_doc["words"] == words
+    assert deck_doc.get("tags") in (["foo", "bar"], "foo,bar", ["foo,bar"], None)
+    assert user_doc and deck_doc["_id"] in user_doc.get("deck_ids", [])
+
+# 3 Game creation and deck retrieval
+@pytest.mark.asyncio
+async def test_game_creation_and_deck(client, created_game):
+    game_id, words = created_game
+    deck_resp = await client.get(f"/api/game/{game_id}/deck")
+    assert deck_resp.status_code == 200
+    assert deck_resp.json() == {"words": words}
+
+# 4 Export deck integration
+@pytest.mark.asyncio
+async def test_export_deck_integration(client, created_game):
+    game_id, words = created_game
+    export = await client.get(f"/api/game/leaderboard/{game_id}/export")
+    assert export.status_code == 200
+    assert export.headers["content-type"].startswith("text/plain")
+    assert "exported_deck_" in export.headers.get("content-disposition", "")
+    assert export.text == "\n".join(words)
+
+# 5 Leaderboard sorting
+@pytest.mark.asyncio
+async def test_leaderboard_sorting(client, test_db):
+    await test_db.games.insert_one({"_id": "L1", "scores": {"alice": 3, "bob": 5, "carol": 2}})
+    res = await client.get("/api/game/leaderboard/L1")
+    assert res.status_code == 200
+    assert list(res.json().keys()) == ["bob", "alice", "carol"]
+
+# additional integration: unauthorized profile access
+@pytest.mark.asyncio
+async def test_profile_requires_auth(client):
+    res = await client.get("/api/profile/me")
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- add pytest configuration and fixtures
- write unit tests for auth routes and utility function
- write integration tests for main user flows and game logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7efb4cfc8329ac57d6abfd79fea4