### PR TITLE
Fix tests setup to avoid linter error

### DIFF
--- a/backend/tests/_test_setup.py
+++ b/backend/tests/_test_setup.py
@@ -1,0 +1,15 @@
+import os
+import types
+import sys
+import mongomock_motor
+
+motor_mock = types.ModuleType("motor")
+motor_asyncio = types.ModuleType("motor.motor_asyncio")
+motor_asyncio.AsyncIOMotorClient = mongomock_motor.AsyncMongoMockClient
+motor_mock.motor_asyncio = motor_asyncio
+sys.modules.setdefault("motor", motor_mock)
+sys.modules.setdefault("motor.motor_asyncio", motor_asyncio)
+
+os.environ.setdefault("SECRET_KEY", "test_secret")
+os.environ.setdefault("ALGORITHM", "HS256")
+os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "30")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,23 +1,9 @@
-import os
-import types
-import sys
+import backend.tests._test_setup  # noqa: F401
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient, ASGITransport
 from fastapi.testclient import TestClient
 import mongomock_motor
-
-
-motor_mock = types.ModuleType("motor")
-motor_asyncio = types.ModuleType("motor.motor_asyncio")
-motor_asyncio.AsyncIOMotorClient = mongomock_motor.AsyncMongoMockClient
-motor_mock.motor_asyncio = motor_asyncio
-sys.modules.setdefault("motor", motor_mock)
-sys.modules.setdefault("motor.motor_asyncio", motor_asyncio)
-
-os.environ.setdefault("SECRET_KEY", "test_secret")
-os.environ.setdefault("ALGORITHM", "HS256")
-os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
 
 from backend.app.main import app as fastapi_app
 import backend.app.services.auth_service as auth_service


### PR DESCRIPTION
## Summary
- introduce `_test_setup.py` to configure env vars and mongomock
- clean up `conftest.py` imports to satisfy flake8

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea08bef308329bd66f210562ee1e0